### PR TITLE
fix to trimming a number, which is not a string

### DIFF
--- a/src/js/timepicker.js
+++ b/src/js/timepicker.js
@@ -253,7 +253,7 @@ class TimePicker {
             if (typeof hours === 'string' || hours instanceof String) {
 		this.cachedEls.displayHours.innerHTML = hours.trim();
             } else {
-                this.cachedEls.displayMinutes.innerHTML = hours;
+                this.cachedEls.displayHours.innerHTML = hours;
             }
         }
 

--- a/src/js/timepicker.js
+++ b/src/js/timepicker.js
@@ -251,7 +251,7 @@ class TimePicker {
         if (hours) {
             // .trim() is not allowed if hours is not recognized as a string,
             if (typeof hours === 'string' || hours instanceof String) {
-	        this.cachedEls.displayHours.innerHTML = hours.trim();
+                this.cachedEls.displayHours.innerHTML = hours.trim();
             } else {
                 this.cachedEls.displayHours.innerHTML = hours;
             }

--- a/src/js/timepicker.js
+++ b/src/js/timepicker.js
@@ -256,8 +256,7 @@ class TimePicker {
                 this.cachedEls.displayHours.innerHTML = hours;
             }
         }
-
-	if (minutes) {
+        if (minutes) {
             const min = minutes < 10 ? `0${minutes}` : minutes;
 
             // .trim() is not allowed if min is not recognized as a string,

--- a/src/js/timepicker.js
+++ b/src/js/timepicker.js
@@ -249,13 +249,24 @@ class TimePicker {
      */
     setDisplayTime({hours, minutes}) {
         if (hours) {
-            this.cachedEls.displayHours.innerHTML = hours.trim();
+            // .trim() is not allowed if hours is not recognized as a string,
+            if (typeof hours === 'string' || hours instanceof String) {
+		this.cachedEls.displayHours.innerHTML = hours.trim();
+            } else {
+                this.cachedEls.displayMinutes.innerHTML = hours;
+            }
         }
 
-        if (minutes) {
+	if (minutes) {
             const min = minutes < 10 ? `0${minutes}` : minutes;
 
-            this.cachedEls.displayMinutes.innerHTML = min.trim();
+            // .trim() is not allowed if min is not recognized as a string,
+            // ... sometimes (in Safari and Chrome) it is an untrimmable number
+            if (typeof min === 'string' || min instanceof String) {
+                this.cachedEls.displayMinutes.innerHTML = min.trim();
+            } else {
+                this.cachedEls.displayMinutes.innerHTML = min;
+            }
         }
     }
 

--- a/src/js/timepicker.js
+++ b/src/js/timepicker.js
@@ -251,7 +251,7 @@ class TimePicker {
         if (hours) {
             // .trim() is not allowed if hours is not recognized as a string,
             if (typeof hours === 'string' || hours instanceof String) {
-		this.cachedEls.displayHours.innerHTML = hours.trim();
+	        this.cachedEls.displayHours.innerHTML = hours.trim();
             } else {
                 this.cachedEls.displayHours.innerHTML = hours;
             }


### PR DESCRIPTION
On mobile safari and desktop chrome, there were errors when .trim() called on minutes.  So I just added guards around this. The error would cause the entire dialog to halt; it seemed worth adding one more check.

![min trim_issue](https://user-images.githubusercontent.com/7432139/30340655-07a6fe52-97a8-11e7-867f-6de967ab2534.png)
![chrom_error](https://user-images.githubusercontent.com/7432139/30341000-5094ef60-97a9-11e7-80a7-a691ff804feb.png)
